### PR TITLE
generate (missing) uuid for backpacks

### DIFF
--- a/src/main/java/ruiseki/okbackpack/client/gui/syncHandler/BackpackSH.java
+++ b/src/main/java/ruiseki/okbackpack/client/gui/syncHandler/BackpackSH.java
@@ -120,10 +120,10 @@ public class BackpackSH extends SyncHandler {
 
     public void updateBackpack(PacketBuffer buf) throws IOException {
         boolean lock = buf.readBoolean();
-        String uuid = buf.readStringFromBuffer(36);
+        String playerUuid = buf.readStringFromBuffer(36);
         boolean tab = buf.readBoolean();
         wrapper.setLockBackpack(lock);
-        wrapper.setUuid(uuid);
+        wrapper.setPlayerUuid(playerUuid);
         wrapper.setKeepTab(tab);
     }
 

--- a/src/main/java/ruiseki/okbackpack/common/block/BackpackWrapper.java
+++ b/src/main/java/ruiseki/okbackpack/common/block/BackpackWrapper.java
@@ -84,6 +84,10 @@ public class BackpackWrapper implements IItemHandlerModifiable, INBTSerializable
 
     @Getter
     @Setter
+    private String playerUuid;
+
+    @Getter
+    @Setter
     private String customName;
 
     @Getter
@@ -105,6 +109,7 @@ public class BackpackWrapper implements IItemHandlerModifiable, INBTSerializable
     public static final String LOCKED_SLOTS_TAG = "LockedSlots";
     public static final String LOCKED_BACKPACK_TAG = "LockedBackpack";
     public static final String UUID_TAG = "UUID";
+    public static final String PLAYER_UUID_TAG = "PlayerUUID";
     public static final String KEEP_TAB_TAG = "KeepTab";
     public static final String CUSTOM_NAME_TAG = "CustomName";
     public static final String SLEEPING_BAG_DEPLOYED_TAG = "SleepingBagDeloyed";
@@ -542,7 +547,14 @@ public class BackpackWrapper implements IItemHandlerModifiable, INBTSerializable
     }
 
     public boolean canPlayerAccess(UUID playerUUID) {
-        return !isLockBackpack() || playerUUID.equals(UUID.fromString(getUuid()));
+        if (!isLockBackpack()) return true;
+
+        var myPlayerUuid = getPlayerUuid();
+        if (myPlayerUuid != null && playerUUID.equals(UUID.fromString(myPlayerUuid))) {
+            return true;
+        }
+
+        return false;
     }
 
     public boolean hasCustomInventoryName() {
@@ -660,7 +672,12 @@ public class BackpackWrapper implements IItemHandlerModifiable, INBTSerializable
 
         tag.setBoolean(KEEP_TAB_TAG, keepTab);
 
-        if (uuid != null) tag.setString(UUID_TAG, uuid);
+        tag.setString(UUID_TAG, uuid);
+
+        if (lockBackpack && playerUuid != null) {
+            tag.setString(PLAYER_UUID_TAG, playerUuid);
+        }
+
         if (hasCustomInventoryName() && this.customName != null) {
             tag.setString(CUSTOM_NAME_TAG, this.customName);
         }
@@ -734,7 +751,16 @@ public class BackpackWrapper implements IItemHandlerModifiable, INBTSerializable
 
         if (tag.hasKey(UUID_TAG, 8)) {
             String tempUuid = tag.getString(UUID_TAG);
-            if (tempUuid.length() > 0) this.uuid = tempUuid;
+            if (tempUuid.length() > 0) { // Backward compatibility - remove this check after some time
+                this.uuid = tempUuid;
+                if (lockBackpack) { // Backward compatibility - remove this whole block after some time
+                    this.playerUuid = tempUuid;
+                }
+            }
+        }
+
+        if (tag.hasKey(PLAYER_UUID_TAG, 8)) {
+            this.playerUuid = tag.getString(PLAYER_UUID_TAG);
         }
 
         if (tag.hasKey("display", 10)) {


### PR DESCRIPTION
## Describe your changes

The uuid generation for backpacks was missing. This had some side-effects.

Now the uuid generates on constructur. This is either used or overwritten on load. For existing backpacks with zero lengh uuid, the loaded uuid will be ignored and the automatically generated one will be used.

## Issue or Enhancement ticket number and link

- #28
- #23
- #24 (probably fixed earlier with #25)

## Checklist before requesting a review
- [x] I have performed a complete self-review of my code (format, style, logic).
- [x] I have added tests or verified that no new tests are required.
- [x] I have updated documentation or release notes if necessary.
