### PR TITLE
fix backpack crash

### DIFF
--- a/src/main/java/ruiseki/okbackpack/client/renderer/model/BackpackModel.java
+++ b/src/main/java/ruiseki/okbackpack/client/renderer/model/BackpackModel.java
@@ -185,9 +185,7 @@ public class BackpackModel implements BakedModel {
         if (context instanceof BakedModelQuadContext.Item itemContext) {
             ItemStack stack = itemContext.getItemStack();
             return BackpackEntityHelpers.getWrapper(stack);
-        }
-
-        if (context instanceof BakedModelQuadContext.World worldContext) {
+        } else if (context instanceof BakedModelQuadContext.World worldContext) {
             IBlockAccess world = worldContext.getWorld();
             if (world != null) {
                 TileEntity te = world.getTileEntity(worldContext.getX(), worldContext.getY(), worldContext.getZ());

--- a/src/main/java/ruiseki/okbackpack/client/renderer/model/BackpackModel.java
+++ b/src/main/java/ruiseki/okbackpack/client/renderer/model/BackpackModel.java
@@ -182,24 +182,21 @@ public class BackpackModel implements BakedModel {
 
     @Nullable
     public static BackpackWrapper getWrapperFromContext(BakedModelQuadContext context) {
-        switch (context) {
-            case BakedModelQuadContext.Item itemContext -> {
-                ItemStack stack = itemContext.getItemStack();
-                return BackpackEntityHelpers.getWrapper(stack);
-            }
-            case BakedModelQuadContext.World worldContext -> {
-                IBlockAccess world = worldContext.getWorld();
-                if (world != null) {
-                    TileEntity te = world.getTileEntity(worldContext.getX(), worldContext.getY(), worldContext.getZ());
-                    if (te instanceof TEBackpack teBackpack) {
-                        return teBackpack.getWrapper();
-                    }
+        if (context instanceof BakedModelQuadContext.Item itemContext) {
+            ItemStack stack = itemContext.getItemStack();
+            return BackpackEntityHelpers.getWrapper(stack);
+        }
+
+        if (context instanceof BakedModelQuadContext.World worldContext) {
+            IBlockAccess world = worldContext.getWorld();
+            if (world != null) {
+                TileEntity te = world.getTileEntity(worldContext.getX(), worldContext.getY(), worldContext.getZ());
+                if (te instanceof TEBackpack teBackpack) {
+                    return teBackpack.getWrapper();
                 }
             }
-            case null, default -> {
-                return null;
-            }
         }
+
         return null;
     }
 }

--- a/src/main/java/ruiseki/okbackpack/common/block/BackpackWrapper.java
+++ b/src/main/java/ruiseki/okbackpack/common/block/BackpackWrapper.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -59,7 +58,7 @@ import ruiseki.okcore.helper.ItemHandlerHelpers;
 import ruiseki.okcore.helper.ItemNBTHelpers;
 import ruiseki.okcore.helper.LangHelpers;
 
-public class BackpackWrapper implements IBackpackWrapper, IInventory {
+public class BackpackWrapper implements IBackpackWrapper {
 
     private static final double MAX_SLEEPING_BAG_DISTANCE_SQ = 32.0D * 32.0D;
     private static final int SLEEPING_BAG_DISTANCE_CHECK_INTERVAL = 10;
@@ -1320,27 +1319,22 @@ public class BackpackWrapper implements IBackpackWrapper, IInventory {
         }
     }
 
-    @Override
     public int getSizeInventory() {
         return this.getSlots();
     }
 
-    @Override
     public ItemStack decrStackSize(int index, int count) {
         return this.extractItem(index, count, false);
     }
 
-    @Override
     public ItemStack getStackInSlotOnClosing(int index) {
         return null;
     }
 
-    @Override
     public void setInventorySlotContents(int index, ItemStack stack) {
         this.setStackInSlot(index, stack);
     }
 
-    @Override
     public boolean hasCustomInventoryName() {
         return this.customName != null && !this.customName.isEmpty();
     }
@@ -1357,23 +1351,18 @@ public class BackpackWrapper implements IBackpackWrapper, IInventory {
         return LangHelpers.localize("container.inventory");
     }
 
-    @Override
     public int getInventoryStackLimit() {
         return this.getSlotLimit(0);
     }
 
-    @Override
     public boolean isUseableByPlayer(EntityPlayer player) {
         return true;
     }
 
-    @Override
     public void openInventory() {}
 
-    @Override
     public void closeInventory() {}
 
-    @Override
     public boolean isItemValidForSlot(int slot, ItemStack stack) {
         return this.isItemValid(slot, stack);
     }

--- a/src/main/java/ruiseki/okbackpack/common/block/BackpackWrapper.java
+++ b/src/main/java/ruiseki/okbackpack/common/block/BackpackWrapper.java
@@ -1319,22 +1319,6 @@ public class BackpackWrapper implements IBackpackWrapper {
         }
     }
 
-    public int getSizeInventory() {
-        return this.getSlots();
-    }
-
-    public ItemStack decrStackSize(int index, int count) {
-        return this.extractItem(index, count, false);
-    }
-
-    public ItemStack getStackInSlotOnClosing(int index) {
-        return null;
-    }
-
-    public void setInventorySlotContents(int index, ItemStack stack) {
-        this.setStackInSlot(index, stack);
-    }
-
     public boolean hasCustomInventoryName() {
         return this.customName != null && !this.customName.isEmpty();
     }
@@ -1349,21 +1333,5 @@ public class BackpackWrapper implements IBackpackWrapper {
             return LangHelpers.localize(tier.getId() + ".name");
         }
         return LangHelpers.localize("container.inventory");
-    }
-
-    public int getInventoryStackLimit() {
-        return this.getSlotLimit(0);
-    }
-
-    public boolean isUseableByPlayer(EntityPlayer player) {
-        return true;
-    }
-
-    public void openInventory() {}
-
-    public void closeInventory() {}
-
-    public boolean isItemValidForSlot(int slot, ItemStack stack) {
-        return this.isItemValid(slot, stack);
     }
 }

--- a/src/main/java/ruiseki/okbackpack/common/inventory/BackpackWrapperInventoryAdapter.java
+++ b/src/main/java/ruiseki/okbackpack/common/inventory/BackpackWrapperInventoryAdapter.java
@@ -1,0 +1,85 @@
+package ruiseki.okbackpack.common.inventory;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+
+import ruiseki.okbackpack.common.block.BackpackWrapper;
+
+public class BackpackWrapperInventoryAdapter implements IInventory {
+
+    private final BackpackWrapper wrapper;
+
+    public BackpackWrapperInventoryAdapter(BackpackWrapper wrapper) {
+        this.wrapper = wrapper;
+    }
+
+    @Override
+    public int getSizeInventory() {
+        return wrapper.getSlots();
+    }
+
+    @Override
+    public ItemStack getStackInSlot(int slot) {
+        return wrapper.getStackInSlot(slot);
+    }
+
+    @Override
+    public ItemStack decrStackSize(int slot, int amount) {
+        return wrapper.extractItem(slot, amount, false);
+    }
+
+    @Override
+    public ItemStack getStackInSlotOnClosing(int slot) {
+        ItemStack stack = wrapper.getStackInSlot(slot);
+        if (stack != null) {
+            wrapper.setStackInSlot(slot, null);
+        }
+        return stack;
+    }
+
+    @Override
+    public void setInventorySlotContents(int slot, ItemStack stack) {
+        wrapper.setStackInSlot(slot, stack);
+    }
+
+    @Override
+    public String getInventoryName() {
+        return wrapper.getInventoryName();
+    }
+
+    @Override
+    public boolean hasCustomInventoryName() {
+        return wrapper.hasCustomInventoryName();
+    }
+
+    @Override
+    public int getInventoryStackLimit() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public void markDirty() {
+        wrapper.markDirty();
+        wrapper.writeToItem();
+    }
+
+    @Override
+    public boolean isUseableByPlayer(EntityPlayer player) {
+        return true;
+    }
+
+    @Override
+    public void openInventory() {}
+
+    @Override
+    public void closeInventory() {
+        wrapper.writeToItem();
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, ItemStack stack) {
+        return wrapper.getStackHandler()
+            .isItemValid(slot, stack);
+    }
+}

--- a/src/main/java/ruiseki/okbackpack/compat/findit/BackpackProvider.java
+++ b/src/main/java/ruiseki/okbackpack/compat/findit/BackpackProvider.java
@@ -17,6 +17,7 @@ import ruiseki.okbackpack.common.block.BackpackWrapper;
 import ruiseki.okbackpack.common.block.BlockBackpack;
 import ruiseki.okbackpack.common.block.TEBackpack;
 import ruiseki.okbackpack.common.helpers.BackpackEntityHelpers;
+import ruiseki.okbackpack.common.inventory.BackpackWrapperInventoryAdapter;
 
 public class BackpackProvider implements IStackFilterProvider {
 
@@ -46,7 +47,7 @@ public class BackpackProvider implements IStackFilterProvider {
         final AnyMultiItemFilter filter = new AnyMultiItemFilter();
         final FluidStackFilter fluidFilter = new FluidStackFilter();
 
-        filter.add(new InventoryStackFilter(player, wrapper));
+        filter.add(new InventoryStackFilter(player, new BackpackWrapperInventoryAdapter(wrapper)));
         for (ITankUpgrade tank : wrapper.gatherCapabilityUpgrades(ITankUpgrade.class)
             .values()) {
             if (tank != null) {

--- a/src/main/java/ruiseki/okbackpack/compat/structurelib/StructureLibCompat.java
+++ b/src/main/java/ruiseki/okbackpack/compat/structurelib/StructureLibCompat.java
@@ -2,7 +2,6 @@ package ruiseki.okbackpack.compat.structurelib;
 
 import java.util.function.Function;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
@@ -13,6 +12,7 @@ import ruiseki.okbackpack.OKBackpack;
 import ruiseki.okbackpack.common.block.BackpackWrapper;
 import ruiseki.okbackpack.common.block.BlockBackpack;
 import ruiseki.okbackpack.common.helpers.BackpackEntityHelpers;
+import ruiseki.okbackpack.common.inventory.BackpackWrapperInventoryAdapter;
 import ruiseki.okbackpack.compat.Mods;
 import ruiseki.okcore.init.IInitListener;
 
@@ -44,85 +44,7 @@ public class StructureLibCompat implements IInitListener {
                 return null;
             }
             BackpackWrapper wrapper = new BackpackWrapper(stack, (BlockBackpack.ItemBackpack) stack.getItem());
-            return new StructureLibBackpackInventory(wrapper);
-        }
-    }
-
-    public static final class StructureLibBackpackInventory implements IInventory {
-
-        public final BackpackWrapper wrapper;
-
-        public StructureLibBackpackInventory(BackpackWrapper wrapper) {
-            this.wrapper = wrapper;
-        }
-
-        @Override
-        public int getSizeInventory() {
-            return wrapper.getSlots();
-        }
-
-        @Override
-        public ItemStack getStackInSlot(int slot) {
-            return wrapper.getStackInSlot(slot);
-        }
-
-        @Override
-        public ItemStack decrStackSize(int slot, int amount) {
-            return wrapper.extractItem(slot, amount, false);
-        }
-
-        @Override
-        public ItemStack getStackInSlotOnClosing(int slot) {
-            ItemStack stack = wrapper.getStackInSlot(slot);
-            if (stack != null) {
-                wrapper.setStackInSlot(slot, null);
-            }
-            return stack;
-        }
-
-        @Override
-        public void setInventorySlotContents(int slot, ItemStack stack) {
-            wrapper.setStackInSlot(slot, stack);
-        }
-
-        @Override
-        public String getInventoryName() {
-            return wrapper.getInventoryName();
-        }
-
-        @Override
-        public boolean hasCustomInventoryName() {
-            return wrapper.hasCustomInventoryName();
-        }
-
-        @Override
-        public int getInventoryStackLimit() {
-            return Integer.MAX_VALUE;
-        }
-
-        @Override
-        public void markDirty() {
-            wrapper.markDirty();
-            wrapper.writeToItem();
-        }
-
-        @Override
-        public boolean isUseableByPlayer(EntityPlayer player) {
-            return true;
-        }
-
-        @Override
-        public void openInventory() {}
-
-        @Override
-        public void closeInventory() {
-            wrapper.writeToItem();
-        }
-
-        @Override
-        public boolean isItemValidForSlot(int slot, ItemStack stack) {
-            return wrapper.getStackHandler()
-                .isItemValid(slot, stack);
+            return new BackpackWrapperInventoryAdapter(wrapper);
         }
     }
 }


### PR DESCRIPTION
## Describe your changes
BackpackWrapper now implements both:
`IBackpackWrapper` / `IStorageWrapper` / `ruiseki.okcore.item.IItemHandler`
`net.minecraft.inventory.IInventory`

Both sets of interfaces contain methods with the same names, such as:
`getStackInSlot(int)`
`markDirty()`

In the development environment, the method names are fine, but after building the production jar, the IInventory side gets remapped to MCP/SRG names:
`getStackInSlot` -> `func_70301_a`
`markDirty` -> `func_70296_d`

in addition, jvmdmg cannot use switch statements with pattern variables, which causes a crash

## Issue or Enhancement ticket number and link
closed #124 

## Checklist before requesting a review
- [x] I have performed a complete self-review of my code (format, style, logic).
- [x] I have added tests or verified that no new tests are required.
- [x] I have updated documentation or release notes if necessary.
