### PR TITLE
✨ refactor(item): Use ItemHelpers for item comparisons

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,7 +36,7 @@
 dependencies {
     implementation("com.github.GTNewHorizons:GTNHLib:0.11.43:dev")
     implementation("com.github.GTNewHorizons:ModularUI2:2.3.87-1.7.10:dev")
-    implementation("com.github.Shigure-Ruiseki:OKCore:26.08.25.0:dev") { transitive = false }
+    implementation("com.github.Shigure-Ruiseki:OKCore:26.08.31.0:dev") { transitive = false }
 
     devOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.125-GTNH:dev")

--- a/src/main/java/ruiseki/okbackpack/api/wrapper/IAdvancedFilterable.java
+++ b/src/main/java/ruiseki/okbackpack/api/wrapper/IAdvancedFilterable.java
@@ -8,7 +8,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import ruiseki.okbackpack.client.gui.handler.BaseItemStackHandler;
-import ruiseki.okcore.helper.ItemStackHelpers;
+import ruiseki.okcore.helper.ItemHelpers;
 
 public interface IAdvancedFilterable extends IBasicFilterable {
 
@@ -159,7 +159,7 @@ public interface IAdvancedFilterable extends IBasicFilterable {
 
         boolean flag;
         if (isIgnoreDurability()) {
-            flag = ItemStackHelpers.areItemsEqualIgnoreDurability(filterStack, stack);
+            flag = ItemHelpers.areItemsEqualIgnoreDurability(filterStack, stack);
         } else {
             flag = filterStack.isItemEqual(stack);
         }

--- a/src/main/java/ruiseki/okbackpack/api/wrapper/IBasicFilterable.java
+++ b/src/main/java/ruiseki/okbackpack/api/wrapper/IBasicFilterable.java
@@ -3,7 +3,7 @@ package ruiseki.okbackpack.api.wrapper;
 import net.minecraft.item.ItemStack;
 
 import ruiseki.okbackpack.client.gui.handler.BaseItemStackHandler;
-import ruiseki.okcore.helper.ItemStackHelpers;
+import ruiseki.okcore.helper.ItemHelpers;
 
 public interface IBasicFilterable {
 
@@ -25,14 +25,14 @@ public interface IBasicFilterable {
         switch (getFilterType()) {
             case WHITELIST:
                 for (ItemStack s : getFilterItems().getStacks()) {
-                    if (ItemStackHelpers.areItemsEqualIgnoreDurability(s, check)) {
+                    if (ItemHelpers.areItemsEqualIgnoreDurability(s, check)) {
                         return true;
                     }
                 }
                 return false;
             case BLACKLIST:
                 for (ItemStack s : getFilterItems().getStacks()) {
-                    if (ItemStackHelpers.areItemsEqualIgnoreDurability(s, check)) {
+                    if (ItemHelpers.areItemsEqualIgnoreDurability(s, check)) {
                         return false;
                     }
                 }

--- a/src/main/java/ruiseki/okbackpack/client/gui/handler/BackpackItemStackHandler.java
+++ b/src/main/java/ruiseki/okbackpack/client/gui/handler/BackpackItemStackHandler.java
@@ -10,7 +10,7 @@ import ruiseki.okbackpack.api.handler.ILockedItemHandler;
 import ruiseki.okbackpack.api.handler.IMemoryItemHandler;
 import ruiseki.okbackpack.common.helpers.BackpackEntityHelpers;
 import ruiseki.okcore.helper.ItemHandlerHelpers;
-import ruiseki.okcore.helper.ItemStackHelpers;
+import ruiseki.okcore.helper.ItemHelpers;
 
 public class BackpackItemStackHandler extends BaseItemStackHandler implements IMemoryItemHandler, ILockedItemHandler {
 
@@ -44,7 +44,7 @@ public class BackpackItemStackHandler extends BaseItemStackHandler implements IM
         if (memorizedSlotRespectNbtList.get(slot)) {
             return ItemStack.areItemStacksEqual(stack, memorizedSlotStack.get(slot));
         }
-        return ItemStackHelpers.areItemsEqualIgnoreDurability(stack, memorizedSlotStack.get(slot));
+        return ItemHelpers.areItemsEqualIgnoreDurability(stack, memorizedSlotStack.get(slot));
     }
 
     @Override

--- a/src/main/java/ruiseki/okbackpack/client/key/PickBlockHandler.java
+++ b/src/main/java/ruiseki/okbackpack/client/key/PickBlockHandler.java
@@ -21,7 +21,7 @@ import ruiseki.okbackpack.common.helpers.BaublesHelpers;
 import ruiseki.okbackpack.common.network.PacketBackpackNBT;
 import ruiseki.okbackpack.common.network.PacketQuickDraw;
 import ruiseki.okcore.client.key.IKeyHandler;
-import ruiseki.okcore.helper.ItemStackHelpers;
+import ruiseki.okcore.helper.ItemHelpers;
 
 public class PickBlockHandler implements IKeyHandler {
 
@@ -97,7 +97,7 @@ public class PickBlockHandler implements IKeyHandler {
         if (baublesInventory != null) {
             for (int i = 0; i < baublesInventory.getSizeInventory(); i++) {
                 ItemStack stack = baublesInventory.getStackInSlot(i);
-                if (stack != null && ItemStackHelpers.areStacksEqual(stack, wanted)) {
+                if (stack != null && ItemHelpers.areItemsEqual(stack, wanted)) {
                     return true;
                 }
             }
@@ -105,13 +105,13 @@ public class PickBlockHandler implements IKeyHandler {
 
         for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
             ItemStack stack = player.inventory.getStackInSlot(i);
-            if (stack != null && ItemStackHelpers.areStacksEqual(stack, wanted)) {
+            if (stack != null && ItemHelpers.areItemsEqual(stack, wanted)) {
                 return true;
             }
         }
 
         for (ItemStack stack : player.inventory.armorInventory) {
-            if (stack != null && ItemStackHelpers.areStacksEqual(stack, wanted)) {
+            if (stack != null && ItemHelpers.areItemsEqual(stack, wanted)) {
                 return true;
             }
         }

--- a/src/main/java/ruiseki/okbackpack/common/block/BackpackPanel.java
+++ b/src/main/java/ruiseki/okbackpack/common/block/BackpackPanel.java
@@ -77,7 +77,7 @@ import ruiseki.okbackpack.client.gui.widget.updateGroup.UpgradeSlotUpdateGroup;
 import ruiseki.okbackpack.client.gui.widget.upgrade.ExpandedTabWidget;
 import ruiseki.okbackpack.client.renderer.RenderHelpers;
 import ruiseki.okbackpack.common.helpers.BackpackInventoryHelpers;
-import ruiseki.okcore.helper.ItemStackHelpers;
+import ruiseki.okcore.helper.ItemHelpers;
 import ruiseki.okcore.helper.LangHelpers;
 import ruiseki.okcore.item.capability.wrapper.PlayerInvWrapper;
 import ruiseki.okcore.item.capability.wrapper.PlayerMainInvWrapper;
@@ -192,7 +192,7 @@ public class BackpackPanel extends ModularPanel implements IStoragePanel<Backpac
                 if (!client) return;
                 ItemStack last = lastUpgradeStacks[slotIndex];
 
-                boolean itemChanged = !ItemStackHelpers.areStacksEqual(last, stack, true);
+                boolean itemChanged = !ItemHelpers.areItemsEqual(last, stack, true);
                 boolean tabDirty = isTabDirty(slotIndex, syncHandler);
 
                 if (!itemChanged && !tabDirty) return;

--- a/src/main/java/ruiseki/okbackpack/common/item/refill/RefillUpgradeWrapper.java
+++ b/src/main/java/ruiseki/okbackpack/common/item/refill/RefillUpgradeWrapper.java
@@ -17,8 +17,8 @@ import ruiseki.okbackpack.api.wrapper.TargetSlot;
 import ruiseki.okbackpack.client.gui.handler.BaseItemStackHandler;
 import ruiseki.okbackpack.common.item.UpgradeWrapperBase;
 import ruiseki.okcore.datastructure.BlockPos;
+import ruiseki.okcore.helper.ItemHelpers;
 import ruiseki.okcore.helper.ItemNBTHelpers;
-import ruiseki.okcore.helper.ItemStackHelpers;
 import ruiseki.okcore.item.handler.IItemHandler;
 
 @Getter
@@ -201,7 +201,7 @@ public class RefillUpgradeWrapper extends UpgradeWrapperBase implements IRefillU
         int range = (targetSlot == TargetSlot.ANY) ? player.inventory.mainInventory.length : 9;
         for (int i = 0; i < range; i++) {
             ItemStack stack = player.inventory.mainInventory[i];
-            if (stack != null && ItemStackHelpers.areItemsEqualIgnoreDurability(stack, filter)) {
+            if (stack != null && ItemHelpers.areItemsEqualIgnoreDurability(stack, filter)) {
                 total += stack.stackSize;
             }
         }
@@ -216,7 +216,7 @@ public class RefillUpgradeWrapper extends UpgradeWrapperBase implements IRefillU
         for (int slot = 0; slot < handler.getSlots(); slot++) {
             ItemStack stack = handler.getStackInSlot(slot);
             if (stack == null || stack.stackSize <= 0) continue;
-            if (!ItemStackHelpers.areItemsEqualIgnoreDurability(stack, filter)) continue;
+            if (!ItemHelpers.areItemsEqualIgnoreDurability(stack, filter)) continue;
             totalAvailable += stack.stackSize;
             if (totalAvailable >= maxCount) return maxCount;
         }
@@ -234,7 +234,7 @@ public class RefillUpgradeWrapper extends UpgradeWrapperBase implements IRefillU
         for (int slot = 0; slot < handler.getSlots() && remaining > 0; slot++) {
             ItemStack stack = handler.getStackInSlot(slot);
             if (stack == null || stack.stackSize <= 0) continue;
-            if (!ItemStackHelpers.areItemsEqualIgnoreDurability(stack, filter)) continue;
+            if (!ItemHelpers.areItemsEqualIgnoreDurability(stack, filter)) continue;
 
             int toTake = Math.min(remaining, stack.stackSize);
             ItemStack extracted = handler.extractItem(slot, toTake, false);


### PR DESCRIPTION
Replace `ItemStackHelpers` with `ItemHelpers` for item comparison methods across the codebase. This change standardizes item comparison logic and improves code maintainability.

## Describe your changes

## Issue or Enhancement ticket number and link

## Checklist before requesting a review
- [x] I have performed a complete self-review of my code (format, style, logic).
- [x] I have added tests or verified that no new tests are required.
- [x] I have updated documentation or release notes if necessary.
